### PR TITLE
Add persistent queue for offline voucher posts

### DIFF
--- a/agent/tally_agent.py
+++ b/agent/tally_agent.py
@@ -1,9 +1,14 @@
 import os
+import time
+import threading
+import requests
 from langchain_openai import ChatOpenAI
 from langchain.prompts import PromptTemplate
 from langchain.chains import LLMChain
 from dotenv import load_dotenv
 from tally_agent_prompt import prompt_template
+from tally_tool.client import TallyClient
+from agent.utils.queue import WriteQueue
 
 # Load environment variables
 load_dotenv()
@@ -11,6 +16,10 @@ load_dotenv()
 # Set OpenRouter variables
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
 os.environ["OPENAI_API_BASE"] = os.getenv("OPENAI_API_BASE")  # Needed for OpenRouter
+
+# Tally client and persistent queue
+tally_client = TallyClient()
+queue = WriteQueue(os.path.join(os.path.dirname(__file__), "voucher_queue.db"))
 
 # Initialize LLM using environment model
 llm = ChatOpenAI(
@@ -28,12 +37,59 @@ prompt = PromptTemplate(
 # LangChain LLMChain
 chain = prompt | llm
 
+
+def is_tally_reachable() -> bool:
+    """Check if the Tally HTTP endpoint is reachable."""
+    try:
+        requests.get(tally_client.url, timeout=3)
+        return True
+    except requests.RequestException:
+        return False
+
+
+def post_xml_with_queue(xml_str: str) -> str | None:
+    """Post XML to Tally or queue it if Tally is unreachable."""
+    if is_tally_reachable():
+        try:
+            return tally_client.post_xml(xml_str)
+        except requests.RequestException:
+            pass
+    queue.enqueue(xml_str, "xml")
+    return None
+
+
+def queue_worker() -> None:
+    """Background worker to resend queued XML to Tally."""
+    while True:
+        tasks = queue.get_pending()
+        if tasks and is_tally_reachable():
+            for task_id, payload, _ in tasks:
+                try:
+                    tally_client.post_xml(payload)
+                    queue.mark_complete(task_id)
+                except requests.RequestException:
+                    pass
+        time.sleep(900)  # 15 minutes
+
+
+worker_thread = threading.Thread(target=queue_worker, daemon=True)
+worker_thread.start()
+
 # Run loop
 def run_agent():
     while True:
         user_input = input("\n💬 Enter a Tally-related query (or type 'exit'):\n> ")
         if user_input.lower() == "exit":
             break
+        if user_input.lower().startswith("xml "):
+            xml_payload = user_input[4:]
+            response = post_xml_with_queue(xml_payload)
+            if response:
+                print("\n🧾 Tally Response:\n", response)
+            else:
+                print("\n🧾 XML queued for later sending.")
+            continue
+
         result = chain.invoke({"user_input": user_input})
         print("\n🧾 Extracted JSON:\n", result)
 

--- a/agent/utils/queue.py
+++ b/agent/utils/queue.py
@@ -1,0 +1,51 @@
+import sqlite3
+from pathlib import Path
+from typing import List, Tuple
+
+
+class WriteQueue:
+    """Simple SQLite-backed queue for voucher data."""
+
+    def __init__(self, db_path: str = "queue.db") -> None:
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self._create_table()
+
+    def _create_table(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queue (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    payload TEXT NOT NULL,
+                    data_type TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+
+    def enqueue(self, payload: str, data_type: str = "xml") -> int:
+        """Add a new item to the queue."""
+        with self.conn:
+            cur = self.conn.execute(
+                "INSERT INTO queue (payload, data_type, status) VALUES (?, ?, 'pending')",
+                (payload, data_type),
+            )
+            return cur.lastrowid
+
+    def get_pending(self) -> List[Tuple[int, str, str]]:
+        cur = self.conn.execute(
+            "SELECT id, payload, data_type FROM queue WHERE status='pending' ORDER BY id"
+        )
+        return cur.fetchall()
+
+    def mark_complete(self, task_id: int) -> None:
+        with self.conn:
+            self.conn.execute(
+                "UPDATE queue SET status='complete' WHERE id=?",
+                (task_id,),
+            )
+
+    def close(self) -> None:
+        self.conn.close()


### PR DESCRIPTION
## Summary
- add `WriteQueue` class to persist unsent vouchers in SQLite
- update `tally_agent` to queue XML posts when Tally isn't reachable
- run a background worker every 15 minutes to flush queued items
- allow `tally_agent` CLI to send XML directly

## Testing
- `python -m py_compile agent/tally_agent.py agent/utils/queue.py tally_tool/client.py`

------
https://chatgpt.com/codex/tasks/task_e_688409f383c0832c93ce718ce3efed3a