### PR TITLE
Implement token-based auth for backend and agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The `backend` package exposes a FastAPI application with a few routes used by th
 - `POST /sync_status` – update the last sync time and Tally access status.
 - `GET /dashboard` – simple HTML dashboard showing client information.
 
+All API requests must include a `Bearer` token in the `Authorization` header. A
+unique token is generated for every client and stored in the `clients` table.
+
 To run the server:
 
 ```bash
@@ -19,3 +22,16 @@ uvicorn backend.main:app --reload
 ```
 
 The application stores its data in `backend/backend.db` (SQLite).
+
+## Agent Configuration
+
+The agent reads its backend credentials from environment variables:
+
+```
+BACKEND_URL=https://example.com
+CLIENT_ID=<your_client_id>
+CLIENT_TOKEN=<generated_token>
+```
+
+When the agent makes a request to the backend it automatically includes
+`CLIENT_TOKEN` in the `Authorization` header.


### PR DESCRIPTION
## Summary
- generate and store a `token` for each client in the backend database
- require a valid token via `Authorization` header for `/upload_voucher`, `/tasks`, and `/sync_status`
- provide helper for authenticating requests
- update agent to read `CLIENT_TOKEN` and send it with API calls
- document configuration for using tokens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68840c341718832c947315edf5d0713c