### PR TITLE
Add invoice PDF generation with WhatsApp sending

### DIFF
--- a/backend/templates/invoice.html
+++ b/backend/templates/invoice.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Invoice</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #333; padding: 8px; }
+        th { background: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>Invoice for Voucher {{ voucher.id }}</h1>
+    <p>Client: {{ voucher.client_id }}</p>
+    <p>Date: {{ voucher.created_at }}</p>
+    <h2>Voucher Data</h2>
+    <pre>{{ voucher.voucher_data }}</pre>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pydantic>=2.0.0
 fastapi>=0.110
 uvicorn>=0.20
 python-multipart>=0.0.5
+pdfkit>=1.0.0
+twilio>=7.0.0


### PR DESCRIPTION
## Summary
- store uploaded vouchers for invoice generation
- create invoice HTML template
- render invoices to PDF and return via `/invoice/<voucher_id>`
- allow sending invoice PDFs via Twilio
- include pdfkit and twilio in requirements

## Testing
- `python -m tally_tool.main` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68840ec38ddc832c90b833b57cc88797