### PR TITLE
Add manual test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@ CLIENT_TOKEN=<generated_token>
 
 When the agent makes a request to the backend it automatically includes
 `CLIENT_TOKEN` in the `Authorization` header.
+
+## Manual testing
+
+The repository provides a small helper script for experimenting with the agent
+without running the interactive CLI. Pipe any text into `tests/manual_test.py`
+and it will output the processed JSON and show if any XML messages were queued:
+
+```bash
+python tests/manual_test.py <<< "Create an invoice for $50"  
+# or use echo
+echo "Create an invoice for $50" | python tests/manual_test.py
+```
+
+If posting XML to Tally fails, the script prints the number of queued items.

--- a/tests/manual_test.py
+++ b/tests/manual_test.py
@@ -1,0 +1,19 @@
+import sys
+from agent.tally_agent import process_message, queue
+
+
+def main() -> None:
+    """Read text from stdin and process it with the Tally agent."""
+    user_text = sys.stdin.read().strip()
+    if not user_text:
+        print("No input provided")
+        return
+    response = process_message(user_text)
+    print(response)
+    pending = queue.get_pending()
+    if pending:
+        print(f"Queued XML count: {len(pending)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tests/manual_test.py` for quick local tests
- document how to use the manual test script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884150c8140832ca55186ecc69781ea