### PR TITLE
Fix package import for tally agent

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,3 @@
+"""Agent package initialization."""
+
+__all__ = ["tally_agent"]

--- a/agent/tally_agent.py
+++ b/agent/tally_agent.py
@@ -5,9 +5,9 @@ import requests
 from langchain_openai import ChatOpenAI
 from langchain.prompts import PromptTemplate
 from dotenv import load_dotenv
-from tally_agent_prompt import prompt_template
+from .tally_agent_prompt import prompt_template
 from tally_tool.client import TallyClient
-from agent.utils.queue import WriteQueue
+from .utils.queue import WriteQueue
 
 # Load environment variables
 load_dotenv()


### PR DESCRIPTION
## Summary
- make `agent` a package with `__init__`
- switch to relative imports in `tally_agent`

## Testing
- `PYTHONPATH=. python tests/manual_test.py <<'EOF'
hello
EOF` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688418efdf18832c93dd63f070f99ae8