### PR TITLE
Handle missing backend gracefully

### DIFF
--- a/agent/tally_agent.py
+++ b/agent/tally_agent.py
@@ -53,7 +53,7 @@ def process_message(user_text: str) -> str:
                 "payload": result,
             },
         )
-    except requests.HTTPError:
+    except requests.RequestException:
         pass
     return result
 


### PR DESCRIPTION
## Summary
- prevent `process_message` from crashing when backend is unreachable by catching `requests.RequestException`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6884199bb17c832cb91a445fd8518cc2